### PR TITLE
fix: scope parse_protocol_queries to Search Terms section

### DIFF
--- a/lib/cli.py
+++ b/lib/cli.py
@@ -178,19 +178,54 @@ def parse_protocol_questions(workspace: Path) -> list[str]:
 
 
 def parse_protocol_queries(workspace: Path) -> list[dict]:
-    """Extract (database, query) pairs from protocol.md search terms table."""
+    """Extract (database, query) pairs from protocol.md Search Terms table.
+
+    Scoped to the ### Search Terms section only.  Normalizes database names
+    to snake_case and strips backtick formatting and trailing category
+    annotations from query text.
+    """
     protocol_path = workspace / "protocol.md"
     if not protocol_path.exists():
         return []
     text = protocol_path.read_text()
+
+    # Scope to Search Terms section (same pattern as count_appendix_a_rows)
+    section_match = re.search(
+        r"(?:^|\n)###\s+Search Terms\s*\n", text
+    )
+    if not section_match:
+        return []
+    section_start = section_match.end()
+    next_section = re.search(r"\n#{1,3}\s+", text[section_start:])
+    section_end = section_start + next_section.start() if next_section else len(text)
+    section_text = text[section_start:section_end]
+
     queries = []
-    # Match table rows with database | query pattern
-    for match in re.finditer(r"\|\s*(\w[\w\s]*?)\s*\|\s*(.+?)\s*\|", text):
+    for match in re.finditer(r"\|\s*(\w[\w\s]*?)\s*\|\s*(.+?)\s*\|", section_text):
         db = match.group(1).strip()
         query = match.group(2).strip()
-        if db.lower() not in ("database", "---", ""):
-            queries.append({"database": db, "query": query})
+        if db.lower() in ("database", "---", ""):
+            continue
+        # Strip backticks and trailing category annotations like (cs.SE, cs.FL)
+        query = re.sub(r"^`|`$", "", query)
+        query = re.sub(r"`\s*\([^)]*\)\s*$", "", query).strip()
+        # Normalize database name
+        db = _normalize_database(db)
+        queries.append({"database": db, "query": query})
     return queries
+
+
+_DB_CANONICAL = {
+    "semantic scholar": "semantic_scholar",
+    "arxiv": "arxiv",
+    "pubmed": "pubmed",
+    "paper-search-mcp": "paper_search_mcp",
+}
+
+
+def _normalize_database(name: str) -> str:
+    """Normalize database name to canonical snake_case form."""
+    return _DB_CANONICAL.get(name.lower().strip(), name.lower().strip().replace(" ", "_"))
 
 
 # --- Command handlers ---

--- a/tests/test_cli_parsers.py
+++ b/tests/test_cli_parsers.py
@@ -1,0 +1,122 @@
+"""Tests for cli.py protocol parsing functions."""
+import json
+import pytest
+from pathlib import Path
+
+from lib.cli import parse_protocol_queries, _normalize_database
+
+
+SAMPLE_PROTOCOL = """\
+# Research Protocol
+
+## Research Question
+
+**Primary question:** Example question?
+
+### Sub-questions
+
+1. Sub-question one?
+
+## Search Strategy
+
+### Search Terms
+
+| Database | Query String |
+|----------|-------------|
+| Semantic Scholar | `"formal verification" AND "safety-critical"` |
+| Semantic Scholar | `"runtime monitoring" AND "procedures"` |
+| arXiv | `"formal methods" AND "operational procedures"` (cs.SE, cs.FL) |
+
+### Databases
+
+- Semantic Scholar
+- arXiv
+
+### Date Range
+
+- **Start year:** 2010
+- **End year:** 2026
+
+## Selection Criteria
+
+### Inclusion Criteria
+
+| ID | Description | Testable Condition |
+|----|-------------|--------------------|
+| IC1 | Addresses verification | Paper describes a method |
+| IC2 | Structured procedures | Has preconditions |
+
+### Exclusion Criteria
+
+| ID | Description | Testable Condition |
+|----|-------------|--------------------|
+| EC1 | Pure software verification | No procedural component |
+
+## Quality Assessment Checklist
+
+| ID | Question |
+|----|----------|
+| QA1 | Is the formalism defined? |
+
+## Data Extraction Schema
+
+| Field Name | Type | Description |
+|------------|------|-------------|
+| paper_id | string | Canonical ID |
+| title | string | Paper title |
+
+## Phase Bounds
+
+| Parameter | Value |
+|-----------|-------|
+| max_results_per_query | 50 |
+| max_snowball_depth | 1 |
+"""
+
+
+@pytest.fixture
+def protocol_workspace(tmp_path):
+    (tmp_path / "protocol.md").write_text(SAMPLE_PROTOCOL)
+    return tmp_path
+
+
+def test_parse_protocol_queries_scoped(protocol_workspace):
+    """Parser returns only Search Terms rows, not criteria/QA/schema/bounds."""
+    queries = parse_protocol_queries(protocol_workspace)
+    assert len(queries) == 3
+
+
+def test_parse_protocol_queries_normalizes_db(protocol_workspace):
+    queries = parse_protocol_queries(protocol_workspace)
+    dbs = [q["database"] for q in queries]
+    assert dbs == ["semantic_scholar", "semantic_scholar", "arxiv"]
+
+
+def test_parse_protocol_queries_strips_backticks(protocol_workspace):
+    queries = parse_protocol_queries(protocol_workspace)
+    for q in queries:
+        assert "`" not in q["query"]
+
+
+def test_parse_protocol_queries_strips_category_annotations(protocol_workspace):
+    queries = parse_protocol_queries(protocol_workspace)
+    arxiv_q = [q for q in queries if q["database"] == "arxiv"][0]
+    assert "(cs.SE" not in arxiv_q["query"]
+    assert arxiv_q["query"] == '"formal methods" AND "operational procedures"'
+
+
+def test_parse_protocol_queries_missing_section(tmp_path):
+    (tmp_path / "protocol.md").write_text("# Protocol\n\nNo search terms here.\n")
+    assert parse_protocol_queries(tmp_path) == []
+
+
+def test_parse_protocol_queries_missing_file(tmp_path):
+    assert parse_protocol_queries(tmp_path) == []
+
+
+def test_normalize_database():
+    assert _normalize_database("Semantic Scholar") == "semantic_scholar"
+    assert _normalize_database("arXiv") == "arxiv"
+    assert _normalize_database("PubMed") == "pubmed"
+    assert _normalize_database("semantic_scholar") == "semantic_scholar"
+    assert _normalize_database("Some New DB") == "some_new_db"


### PR DESCRIPTION
## Summary
- Scopes `parse_protocol_queries` regex to `### Search Terms` section only (was matching all 47 table rows in protocol.md)
- Normalizes database names to snake_case (`Semantic Scholar` -> `semantic_scholar`)
- Strips backtick formatting and trailing `(cs.SE, cs.FL)` annotations from queries
- Adds 7 tests covering scoping, normalization, and edge cases

Fixes #5

## Test plan
- [x] 7 new tests in `tests/test_cli_parsers.py` pass
- [x] Full suite (92 tests) passes