### PR TITLE
docs: canonical database naming in search runbook

### DIFF
--- a/runbooks/search.md
+++ b/runbooks/search.md
@@ -58,6 +58,8 @@ After each query, append to `logs/search-log.jsonl`:
 {"query": "{query}", "database": "{database}", "timestamp": "{ISO-8601}", "result_count": {N}, "parameters": {"limit": {N}, "year_range": "{start}-{end}"}}
 ```
 
+Database names MUST use canonical form: `semantic_scholar`, `arxiv`, `pubmed`, `paper_search_mcp`.
+
 ### Step 3: Build Candidate Records
 For each result, construct a candidate record:
 ```json


### PR DESCRIPTION
## Summary
- Adds canonical database name convention (`semantic_scholar`, `arxiv`, `pubmed`, `paper_search_mcp`) to the search-log schema in `runbooks/search.md`

Fixes #7