### PR TITLE
fix: filter event entries in check_query_counts_per_database

### DIFF
--- a/lib/postconditions.py
+++ b/lib/postconditions.py
@@ -235,7 +235,9 @@ def check_query_counts_per_database(
         normalize_database(pq["database"]) for pq in protocol_queries
     )
     log_counts: dict[str, int] = Counter(
-        normalize_database(e["database"]) for e in search_log
+        normalize_database(e["database"])
+        for e in search_log
+        if "database" in e
     )
     failures = []
     for db, expected in protocol_counts.items():

--- a/tests/test_postcondition_p1.py
+++ b/tests/test_postcondition_p1.py
@@ -97,6 +97,29 @@ def test_check_query_counts_empty_protocol():
     assert satisfied is True
 
 
+def test_check_query_counts_skips_event_entries():
+    """Event entries (e.g., unpaywall_unavailable) lack database key and must not crash."""
+    protocol = [{"database": "semantic_scholar", "query": "q1"}]
+    log = [
+        {"timestamp": "2026-04-10T04:29:00Z", "event": "unpaywall_unavailable", "phase": 1, "details": {"reason": "MCP not configured"}},
+        {"timestamp": "2026-04-10T04:29:00Z", "event": "paper_search_unavailable", "phase": 1, "details": {"reason": "MCP not configured"}},
+        {"database": "semantic_scholar", "query": "q1"},
+    ]
+    satisfied, failures = check_query_counts_per_database(protocol, log)
+    assert satisfied is True
+    assert failures == []
+
+
+def test_check_query_counts_all_events_no_queries():
+    """Log with only event entries and no actual queries should report deficit."""
+    protocol = [{"database": "semantic_scholar", "query": "q1"}]
+    log = [
+        {"event": "pubmed_unavailable", "phase": 1},
+    ]
+    satisfied, failures = check_query_counts_per_database(protocol, log)
+    assert satisfied is False
+
+
 def test_check_phase1_all_integration():
     """End-to-end: protocol queries + search log + candidates."""
     protocol_queries = [


### PR DESCRIPTION
## Summary
- `check_query_counts_per_database` crashes with `KeyError: 'database'` when `search-log.jsonl` contains event entries (e.g., `unpaywall_unavailable`) that lack `database`/`query` keys
- Add `if "database" in e` filter to the log counter comprehension
- Add 2 tests: event entries skipped correctly, and all-events-no-queries reports deficit

## Test plan
- [x] 2 new tests pass (`test_check_query_counts_skips_event_entries`, `test_check_query_counts_all_events_no_queries`)
- [x] Full suite: 104 passed, 0 failed
- [ ] Verify against workspaces with event entries (supersession, tattoo-ink)

Closes #18 (Problem 2a — search-log event entry crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)