### PR TITLE
docs: explicit snowball metadata enrichment and S2 query syntax guidance

### DIFF
--- a/runbooks/search.md
+++ b/runbooks/search.md
@@ -24,6 +24,14 @@ Read `{workspace}/protocol.md`. Extract:
 For each (database, query) pair:
 
 **Semantic Scholar:**
+
+**Query syntax note:** Semantic Scholar's search endpoint accepts plain-text
+keyword queries only. Boolean operators (AND, OR, NOT) and quoted phrases are
+NOT supported — they will be treated as literal search terms. If the protocol
+specifies Boolean queries for Semantic Scholar, convert them to space-separated
+keywords before executing. Use the `fieldsOfStudy`, `year`, and `venue` API
+parameters for structured filtering instead of query-level Boolean logic.
+
 - Use `mcp__semantic-scholar__search_paper` with the query string
 - Parameters: query={query}, limit={max_results_per_query}, year={start}-{end}
 - Record each result's: paperId, title, abstract, authors, year, venue, citationCount, externalIds (DOI, ArXiv)

--- a/runbooks/snowball.md
+++ b/runbooks/snowball.md
@@ -59,7 +59,24 @@ Papers in included.jsonl that are NOT in the already-snowballed set.
      Append to snowball-log.jsonl and skip.
 
    - If new paper:
-     a. Fetch metadata (title, abstract, authors, year, venue)
+     a. **Fetch full metadata** (REQUIRED — do not use citation list data alone):
+        Call `mcp__semantic-scholar__get_paper` with the paper's S2 ID and
+        `fields=title,abstract,authors,year,venue,externalIds,citationCount`.
+        Populate ALL candidate record fields from the response:
+        - `title` — paper title
+        - `abstract` — full abstract text
+        - `authors` — list of author name strings (e.g., `["Alice Smith", "Bob Jones"]`)
+        - `year` — publication year
+        - `venue` — journal or conference name
+        - `doi` — from externalIds.DOI if present
+        - `arxiv_id` — from externalIds.ArXiv if present
+        - `s2_id` — the Semantic Scholar paper ID
+        - `citation_count` — from citationCount
+
+        If the API returns an empty or null authors list, set authors to
+        `["[metadata unavailable]"]` rather than `[]`. This ensures downstream
+        postcondition checks (`check_minimum_metadata`) can distinguish between
+        "not fetched" and "genuinely authorless."
      b. Construct candidate record (same schema as search agent)
      c. Set `source` = `snowball_backward` or `snowball_forward`
      d. Set `discovered_from_paper` = seed paper ID

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -146,16 +146,21 @@ Example: Primary question "How do transformer architectures affect NLP performan
 2. How does model scale interact with architectural choices in transformer NLP systems?
 3. What are the documented failure modes of transformer-based NLP models?
 
-**Field 2: Search Terms and Boolean Queries**
+**Field 2: Search Terms and Queries**
 
-For each target database (Semantic Scholar, arXiv), generate Boolean query strings:
+For each target database, generate appropriately formatted query strings:
 - Identify the core concepts from the research question
 - Generate synonyms and related terms for each concept
-- Construct Boolean queries using AND/OR/NOT operators
+- Construct queries appropriate to each database's syntax (see below)
 - Suggest 2–4 query variants per database to maximize recall
 - Format: present a table with database and query string columns
 
-Note: Semantic Scholar supports fielded search. arXiv supports category filters (e.g., `cs.AI`, `cs.CL`). Suggest appropriate constraints.
+**Database query syntax:**
+- **PubMed:** Supports full Boolean syntax (AND, OR, NOT), quoted phrases, MeSH terms, and field tags
+- **Semantic Scholar:** Plain-text keyword queries only — no Boolean operators or quoted phrases. Use API parameters (`fieldsOfStudy`, `year`, `venue`) for filtering
+- **arXiv:** Supports Boolean operators (AND, OR, ANDNOT), quoted phrases, and field-specific prefixes (ti:, au:, abs:). Category filters (e.g., `cs.AI`, `cs.CL`) improve relevance
+
+When generating query strings, format them appropriately for each database rather than using a single Boolean query across all databases.
 
 **Field 3: Inclusion Criteria**
 


### PR DESCRIPTION
## Summary
- Expand snowball.md metadata fetch instruction to require a dedicated `get_paper` call per discovered paper, with explicit field mapping. Prevents empty author arrays that cascade to generic BibTeX keys in synthesis.
- Add Semantic Scholar plain-text query syntax note to search.md
- Update SKILL.md Field 2 with per-database query format guidance (PubMed Boolean, S2 keyword, arXiv Boolean+field prefixes)

## Test plan
- [ ] Run a new review and confirm snowball agent populates author fields
- [ ] Confirm search agent uses keyword queries for Semantic Scholar

Closes #1, addresses #18 (Problem 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)