### PR TITLE
test: add coverage for state, saturation, metrics, and extraction propagation

### DIFF
--- a/tests/test_e2e_extraction.py
+++ b/tests/test_e2e_extraction.py
@@ -1,0 +1,87 @@
+"""Tests for synthesis claim validation — extraction completeness propagation.
+
+Exercises validate_synthesis_claims from lib/postconditions.py, focusing on
+the requirement that citations to low-completeness papers include a
+[limited data] qualification marker.
+"""
+import pytest
+
+from lib.postconditions import validate_synthesis_claims
+
+
+class TestLowCompletenessQualification:
+    """Paragraphs citing papers with low extraction completeness must include
+    a [limited data] marker."""
+
+    def test_missing_marker_fails(self):
+        """Citation to a low-completeness paper WITHOUT [limited data] should fail."""
+        paragraphs = [
+            {
+                "section": "Results",
+                "text": "The approach showed promising outcomes [@smith2023].",
+            }
+        ]
+        included_keys = {"smith2023"}
+        extraction_completeness = {"smith2023": 0.3}  # below default 0.5
+
+        satisfied, failures = validate_synthesis_claims(
+            paragraphs, included_keys, extraction_completeness
+        )
+        assert satisfied is False
+        assert len(failures) == 1
+        assert "smith2023" in failures[0]
+        assert "low data completeness" in failures[0]
+
+    def test_with_marker_passes(self):
+        """Citation to a low-completeness paper WITH [limited data] should pass."""
+        paragraphs = [
+            {
+                "section": "Results",
+                "text": (
+                    "The approach showed promising outcomes [@smith2023] "
+                    "[limited data]."
+                ),
+            }
+        ]
+        included_keys = {"smith2023"}
+        extraction_completeness = {"smith2023": 0.3}
+
+        satisfied, failures = validate_synthesis_claims(
+            paragraphs, included_keys, extraction_completeness
+        )
+        assert satisfied is True
+        assert failures == []
+
+    def test_high_completeness_needs_no_marker(self):
+        """Papers above the completeness threshold need no marker."""
+        paragraphs = [
+            {
+                "section": "Discussion",
+                "text": "Results align with prior work [@jones2024].",
+            }
+        ]
+        included_keys = {"jones2024"}
+        extraction_completeness = {"jones2024": 0.8}
+
+        satisfied, failures = validate_synthesis_claims(
+            paragraphs, included_keys, extraction_completeness
+        )
+        assert satisfied is True
+        assert failures == []
+
+    def test_limited_alias_also_accepted(self):
+        """The source also accepts [limited] as an alternative marker."""
+        paragraphs = [
+            {
+                "section": "Results",
+                "text": "Preliminary findings [@low2023] [limited] suggest caution.",
+            }
+        ]
+        included_keys = {"low2023"}
+        extraction_completeness = {"low2023": 0.2}
+
+        satisfied, failures = validate_synthesis_claims(
+            paragraphs, included_keys, extraction_completeness
+        )
+        assert satisfied is True
+        assert failures == []

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,194 @@
+"""Tests for lib/metrics.py — pure counting functions."""
+import pytest
+
+from lib.metrics import (
+    count_excluded,
+    count_flagged,
+    count_included,
+    count_candidates,
+    max_snowball_depth,
+    count_concepts,
+    count_extractions,
+    recompute_all,
+)
+
+
+# --- count_excluded ---
+
+class TestCountExcluded:
+    def test_basic(self):
+        log = [
+            {"decision": "exclude"},
+            {"decision": "include"},
+            {"decision": "exclude"},
+        ]
+        assert count_excluded(log) == 2
+
+    def test_empty(self):
+        assert count_excluded([]) == 0
+
+    def test_no_excludes(self):
+        log = [{"decision": "include"}, {"decision": "flag_for_full_text"}]
+        assert count_excluded(log) == 0
+
+    def test_missing_decision_key(self):
+        log = [{"paper_id": "p1"}]
+        assert count_excluded(log) == 0
+
+
+# --- count_flagged ---
+
+class TestCountFlagged:
+    def test_basic(self):
+        log = [
+            {"decision": "flag_for_full_text"},
+            {"decision": "include"},
+            {"decision": "flag_for_full_text"},
+        ]
+        assert count_flagged(log) == 2
+
+    def test_empty(self):
+        assert count_flagged([]) == 0
+
+    def test_no_flagged(self):
+        log = [{"decision": "include"}, {"decision": "exclude"}]
+        assert count_flagged(log) == 0
+
+
+# --- count_included ---
+
+class TestCountIncluded:
+    def test_basic(self):
+        assert count_included([{"id": "p1"}, {"id": "p2"}]) == 2
+
+    def test_empty(self):
+        assert count_included([]) == 0
+
+
+# --- count_candidates ---
+
+class TestCountCandidates:
+    def test_basic(self):
+        assert count_candidates([{"id": "c1"}, {"id": "c2"}, {"id": "c3"}]) == 3
+
+    def test_empty(self):
+        assert count_candidates([]) == 0
+
+
+# --- max_snowball_depth ---
+
+class TestMaxSnowballDepth:
+    def test_basic(self):
+        log = [
+            {"depth_level": 1},
+            {"depth_level": 3},
+            {"depth_level": 2},
+        ]
+        assert max_snowball_depth(log) == 3
+
+    def test_empty(self):
+        assert max_snowball_depth([]) == 0
+
+    def test_missing_depth_level(self):
+        log = [{"source_paper_id": "p1"}]
+        assert max_snowball_depth(log) == 0
+
+    def test_single_entry(self):
+        assert max_snowball_depth([{"depth_level": 5}]) == 5
+
+
+# --- count_concepts ---
+
+class TestCountConcepts:
+    def test_basic(self):
+        assert count_concepts([{"concept_id": "c1"}, {"concept_id": "c2"}]) == 2
+
+    def test_empty(self):
+        assert count_concepts([]) == 0
+
+
+# --- count_extractions ---
+
+class TestCountExtractions:
+    def test_basic(self):
+        extractions = [
+            {"paper_id": "p1", "fields": []},
+            {"paper_id": "p2", "fields": []},
+            {"paper_id": "p3", "fields": []},
+        ]
+        assert count_extractions(extractions) == 3
+
+    def test_empty(self):
+        assert count_extractions([]) == 0
+
+    def test_deduplication(self):
+        """Same paper_id appearing multiple times counts as 1."""
+        extractions = [
+            {"paper_id": "p1", "fields": []},
+            {"paper_id": "p1", "fields": []},
+            {"paper_id": "p2", "fields": []},
+        ]
+        assert count_extractions(extractions) == 2
+
+    def test_missing_paper_id_excluded(self):
+        """Entries without paper_id are silently skipped."""
+        extractions = [
+            {"paper_id": "p1"},
+            {"fields": []},
+        ]
+        assert count_extractions(extractions) == 1
+
+
+# --- recompute_all ---
+
+class TestRecomputeAll:
+    def test_representative_inputs(self):
+        screening_log = [
+            {"decision": "exclude"},
+            {"decision": "include"},
+            {"decision": "flag_for_full_text"},
+            {"decision": "exclude"},
+        ]
+        candidates = [{"id": "c1"}, {"id": "c2"}, {"id": "c3"}]
+        included = [{"id": "p1"}]
+        snowball_log = [{"depth_level": 1}, {"depth_level": 2}]
+        extractions = [{"paper_id": "p1"}, {"paper_id": "p2"}]
+        concepts = [{"concept_id": "x"}, {"concept_id": "y"}, {"concept_id": "z"}]
+
+        result = recompute_all(
+            screening_log, candidates, included,
+            snowball_log, extractions, concepts,
+        )
+        assert result["total_candidates"] == 3
+        assert result["total_included"] == 1
+        assert result["total_excluded"] == 2
+        assert result["total_flagged"] == 1
+        assert result["snowball_depth_reached"] == 2
+        assert result["concepts_count"] == 3
+        assert result["extraction_complete_count"] == 2
+
+    def test_all_empty(self):
+        result = recompute_all([], [], [], [], [], [])
+        assert result["total_candidates"] == 0
+        assert result["total_included"] == 0
+        assert result["total_excluded"] == 0
+        assert result["total_flagged"] == 0
+        assert result["snowball_depth_reached"] == 0
+        assert result["concepts_count"] == 0
+        assert result["extraction_complete_count"] == 0
+
+    def test_accounting_identity(self):
+        """excluded + flagged + included_decisions == total screened entries with decisions."""
+        screening_log = [
+            {"decision": "exclude"},
+            {"decision": "include"},
+            {"decision": "flag_for_full_text"},
+            {"decision": "include"},
+            {"decision": "exclude"},
+        ]
+        excluded = count_excluded(screening_log)
+        flagged = count_flagged(screening_log)
+        included_decisions = sum(
+            1 for e in screening_log if e.get("decision") == "include"
+        )
+        assert excluded + flagged + included_decisions == len(screening_log)

--- a/tests/test_saturation.py
+++ b/tests/test_saturation.py
@@ -1,0 +1,170 @@
+"""Tests for lib/saturation.py — saturation metrics with exact rational arithmetic."""
+import pytest
+from fractions import Fraction
+
+from lib.saturation import (
+    discovery_saturation,
+    conceptual_saturation,
+    should_terminate_discovery,
+    should_feedback_loop,
+)
+
+
+# --- discovery_saturation ---
+
+class TestDiscoverySaturation:
+    def test_basic_computation(self):
+        log = [
+            {"depth_level": 1, "screening_decision": "include", "already_known": False},
+            {"depth_level": 1, "screening_decision": "exclude"},
+            {"depth_level": 1, "screening_decision": "include", "already_known": False},
+            {"depth_level": 1, "screening_decision": "include", "already_known": True},
+        ]
+        # 2 newly included out of 4 examined at depth 1
+        assert discovery_saturation(log, 1) == Fraction(2, 4)
+
+    def test_empty_log(self):
+        assert discovery_saturation([], 1) == Fraction(0)
+
+    def test_no_entries_at_depth(self):
+        log = [{"depth_level": 2, "screening_decision": "include", "already_known": False}]
+        assert discovery_saturation(log, 1) == Fraction(0)
+
+    def test_all_already_known(self):
+        log = [
+            {"depth_level": 1, "screening_decision": "include", "already_known": True},
+            {"depth_level": 1, "screening_decision": "include", "already_known": True},
+        ]
+        assert discovery_saturation(log, 1) == Fraction(0, 2)
+
+    def test_all_new_includes(self):
+        log = [
+            {"depth_level": 1, "screening_decision": "include", "already_known": False},
+            {"depth_level": 1, "screening_decision": "include", "already_known": False},
+        ]
+        assert discovery_saturation(log, 1) == Fraction(1)
+
+    def test_filters_by_depth(self):
+        log = [
+            {"depth_level": 1, "screening_decision": "include", "already_known": False},
+            {"depth_level": 2, "screening_decision": "include", "already_known": False},
+            {"depth_level": 2, "screening_decision": "exclude"},
+        ]
+        assert discovery_saturation(log, 2) == Fraction(1, 2)
+
+    def test_returns_fraction_type(self):
+        log = [{"depth_level": 1, "screening_decision": "exclude"}]
+        result = discovery_saturation(log, 1)
+        assert isinstance(result, Fraction)
+
+
+# --- conceptual_saturation ---
+
+class TestConceptualSaturation:
+    def test_basic_computation(self):
+        concepts = [
+            {"concept_id": "c1", "first_seen_in": "p1"},
+            {"concept_id": "c2", "first_seen_in": "p2"},
+            {"concept_id": "c3", "first_seen_in": "p1"},
+            {"concept_id": "c4", "first_seen_in": "p3"},
+        ]
+        last_k = {"p2", "p3"}
+        # c2 and c4 first seen in last_k → 2/4
+        assert conceptual_saturation(concepts, last_k) == Fraction(2, 4)
+
+    def test_empty_concepts(self):
+        assert conceptual_saturation([], {"p1"}) == Fraction(0)
+
+    def test_no_overlap(self):
+        concepts = [
+            {"concept_id": "c1", "first_seen_in": "p1"},
+            {"concept_id": "c2", "first_seen_in": "p2"},
+        ]
+        assert conceptual_saturation(concepts, {"p99"}) == Fraction(0, 2)
+
+    def test_all_in_last_k(self):
+        concepts = [
+            {"concept_id": "c1", "first_seen_in": "p1"},
+            {"concept_id": "c2", "first_seen_in": "p1"},
+        ]
+        assert conceptual_saturation(concepts, {"p1"}) == Fraction(1)
+
+    def test_returns_fraction_type(self):
+        concepts = [{"concept_id": "c1", "first_seen_in": "p1"}]
+        result = conceptual_saturation(concepts, set())
+        assert isinstance(result, Fraction)
+
+
+# --- should_terminate_discovery ---
+
+class TestShouldTerminateDiscovery:
+    def test_below_threshold_terminates(self):
+        assert should_terminate_discovery(Fraction(1, 10), Fraction(2, 10)) is True
+
+    def test_above_threshold_continues(self):
+        assert should_terminate_discovery(Fraction(3, 10), Fraction(2, 10)) is False
+
+    def test_equal_to_threshold_does_not_terminate(self):
+        """At exactly the threshold, saturation is NOT < threshold, so returns False."""
+        assert should_terminate_discovery(Fraction(2, 10), Fraction(2, 10)) is False
+
+    def test_zero_saturation(self):
+        assert should_terminate_discovery(Fraction(0), Fraction(1, 10)) is True
+
+    def test_zero_threshold(self):
+        """Zero saturation is not < zero threshold."""
+        assert should_terminate_discovery(Fraction(0), Fraction(0)) is False
+
+
+# --- should_feedback_loop ---
+
+class TestShouldFeedbackLoop:
+    def test_delta_above_and_iterations_available(self):
+        assert should_feedback_loop(
+            delta=Fraction(3, 10),
+            theta_c=Fraction(2, 10),
+            iterations=0,
+            max_iterations=3,
+        ) is True
+
+    def test_delta_equal_to_theta(self):
+        """delta >= theta_c means equal should return True."""
+        assert should_feedback_loop(
+            delta=Fraction(2, 10),
+            theta_c=Fraction(2, 10),
+            iterations=0,
+            max_iterations=3,
+        ) is True
+
+    def test_delta_below_theta(self):
+        assert should_feedback_loop(
+            delta=Fraction(1, 10),
+            theta_c=Fraction(2, 10),
+            iterations=0,
+            max_iterations=3,
+        ) is False
+
+    def test_iterations_exhausted(self):
+        assert should_feedback_loop(
+            delta=Fraction(5, 10),
+            theta_c=Fraction(2, 10),
+            iterations=3,
+            max_iterations=3,
+        ) is False
+
+    def test_iterations_at_max_minus_one(self):
+        assert should_feedback_loop(
+            delta=Fraction(5, 10),
+            theta_c=Fraction(2, 10),
+            iterations=2,
+            max_iterations=3,
+        ) is True
+
+    def test_zero_max_iterations(self):
+        """With max_iterations=0, feedback should never happen."""
+        assert should_feedback_loop(
+            delta=Fraction(1),
+            theta_c=Fraction(0),
+            iterations=0,
+            max_iterations=0,
+        ) is False

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,278 @@
+"""Tests for lib/state.py — phase state machine transitions."""
+import pytest
+
+from lib.state import (
+    PhaseStatus,
+    make_state,
+    start_phase,
+    complete_phase,
+    fail_phase,
+    transition_to_next,
+    retry_phase,
+    diagnostic_transition,
+    feedback_loop,
+    is_review_complete,
+)
+
+
+# --- make_state ---
+
+class TestMakeState:
+    def test_defaults(self):
+        s = make_state()
+        assert s["current_phase"] == 0
+        assert s["phase_status"] == "pending"
+        assert s["feedback_iterations"] == 0
+        assert s["retry_count"] == 0
+        assert s["phase_completed"] == [False] * 6
+
+    def test_custom_values(self):
+        completed = [True, True, False, False, False, False]
+        s = make_state(
+            current_phase=2,
+            phase_status="in_progress",
+            feedback_iterations=1,
+            retry_count=0,
+            phase_completed=completed,
+        )
+        assert s["current_phase"] == 2
+        assert s["phase_status"] == "in_progress"
+        assert s["feedback_iterations"] == 1
+        assert s["phase_completed"] == completed
+
+    def test_phase_completed_is_copied(self):
+        original = [False] * 6
+        s = make_state(phase_completed=original)
+        s["phase_completed"][0] = True
+        assert original[0] is False
+
+    def test_invalid_phase_too_low(self):
+        with pytest.raises(ValueError, match="current_phase must be in"):
+            make_state(current_phase=-1)
+
+    def test_invalid_phase_too_high(self):
+        with pytest.raises(ValueError, match="current_phase must be in"):
+            make_state(current_phase=6)
+
+    def test_invalid_status(self):
+        with pytest.raises(ValueError):
+            make_state(phase_status="bogus")
+
+    def test_negative_feedback_iterations(self):
+        with pytest.raises(ValueError, match="feedback_iterations"):
+            make_state(feedback_iterations=-1)
+
+    def test_negative_retry_count(self):
+        with pytest.raises(ValueError, match="retry_count"):
+            make_state(retry_count=-1)
+
+    def test_wrong_length_phase_completed(self):
+        with pytest.raises(ValueError, match="exactly 6"):
+            make_state(phase_completed=[False] * 5)
+
+
+# --- start_phase ---
+
+class TestStartPhase:
+    def test_happy_path(self):
+        s = make_state(current_phase=0, phase_status="pending")
+        result = start_phase(s, 0)
+        assert result["phase_status"] == PhaseStatus.IN_PROGRESS
+
+    def test_wrong_phase_raises(self):
+        s = make_state(current_phase=0, phase_status="pending")
+        with pytest.raises(ValueError, match="Cannot start phase 1"):
+            start_phase(s, 1)
+
+    def test_not_pending_raises(self):
+        s = make_state(current_phase=0, phase_status="in_progress")
+        with pytest.raises(ValueError, match="expected pending"):
+            start_phase(s, 0)
+
+
+# --- complete_phase ---
+
+class TestCompletePhase:
+    def test_happy_path(self):
+        s = make_state(current_phase=2, phase_status="in_progress")
+        result = complete_phase(s, 2)
+        assert result["phase_status"] == PhaseStatus.COMPLETED
+        assert result["phase_completed"][2] is True
+
+    def test_does_not_mutate_original(self):
+        s = make_state(current_phase=0, phase_status="in_progress")
+        result = complete_phase(s, 0)
+        assert s["phase_completed"][0] is False
+        assert result["phase_completed"][0] is True
+
+    def test_wrong_phase_raises(self):
+        s = make_state(current_phase=0, phase_status="in_progress")
+        with pytest.raises(ValueError, match="Cannot complete phase 3"):
+            complete_phase(s, 3)
+
+    def test_not_in_progress_raises(self):
+        s = make_state(current_phase=0, phase_status="pending")
+        with pytest.raises(ValueError, match="expected in_progress"):
+            complete_phase(s, 0)
+
+
+# --- fail_phase ---
+
+class TestFailPhase:
+    def test_happy_path(self):
+        s = make_state(current_phase=1, phase_status="in_progress")
+        result = fail_phase(s, 1)
+        assert result["phase_status"] == PhaseStatus.FAILED
+
+    def test_wrong_phase_raises(self):
+        s = make_state(current_phase=1, phase_status="in_progress")
+        with pytest.raises(ValueError, match="Cannot fail phase 0"):
+            fail_phase(s, 0)
+
+    def test_not_in_progress_raises(self):
+        s = make_state(current_phase=1, phase_status="pending")
+        with pytest.raises(ValueError, match="expected in_progress"):
+            fail_phase(s, 1)
+
+
+# --- transition_to_next ---
+
+class TestTransitionToNext:
+    def test_happy_path(self):
+        s = make_state(current_phase=0, phase_status="completed")
+        result = transition_to_next(s)
+        assert result["current_phase"] == 1
+        assert result["phase_status"] == PhaseStatus.PENDING
+        assert result["retry_count"] == 0
+
+    def test_not_completed_raises(self):
+        s = make_state(current_phase=0, phase_status="in_progress")
+        with pytest.raises(ValueError, match="expected completed"):
+            transition_to_next(s)
+
+    def test_at_phase_5_raises(self):
+        s = make_state(current_phase=5, phase_status="completed",
+                       phase_completed=[True]*6)
+        with pytest.raises(ValueError, match="already at phase 5"):
+            transition_to_next(s)
+
+    def test_resets_retry_count(self):
+        s = make_state(current_phase=1, phase_status="completed", retry_count=1)
+        result = transition_to_next(s)
+        assert result["retry_count"] == 0
+
+
+# --- retry_phase ---
+
+class TestRetryPhase:
+    def test_happy_path(self):
+        s = make_state(current_phase=2, phase_status="failed", retry_count=0)
+        result = retry_phase(s)
+        assert result["phase_status"] == PhaseStatus.IN_PROGRESS
+        assert result["retry_count"] == 1
+
+    def test_not_failed_raises(self):
+        s = make_state(current_phase=2, phase_status="in_progress")
+        with pytest.raises(ValueError, match="expected failed"):
+            retry_phase(s)
+
+    def test_retry_exhausted_raises(self):
+        s = make_state(current_phase=2, phase_status="failed", retry_count=1)
+        with pytest.raises(ValueError, match="Retry exhausted"):
+            retry_phase(s)
+
+
+# --- diagnostic_transition ---
+
+class TestDiagnosticTransition:
+    def test_happy_path(self):
+        s = make_state(current_phase=2, phase_status="completed")
+        result = diagnostic_transition(s)
+        assert result["phase_status"] == PhaseStatus.NEEDS_PROTOCOL_REVISION
+
+    def test_wrong_phase_raises(self):
+        s = make_state(current_phase=3, phase_status="completed")
+        with pytest.raises(ValueError, match="only valid at phase 2"):
+            diagnostic_transition(s)
+
+    def test_not_completed_raises(self):
+        s = make_state(current_phase=2, phase_status="in_progress")
+        with pytest.raises(ValueError, match="expected completed"):
+            diagnostic_transition(s)
+
+
+# --- feedback_loop ---
+
+class TestFeedbackLoop:
+    def test_happy_path(self):
+        s = make_state(current_phase=4, phase_status="completed",
+                       feedback_iterations=0)
+        result = feedback_loop(s, max_iterations=3)
+        assert result["current_phase"] == 3
+        assert result["phase_status"] == PhaseStatus.PENDING
+        assert result["feedback_iterations"] == 1
+        assert result["retry_count"] == 0
+
+    def test_wrong_phase_raises(self):
+        s = make_state(current_phase=3, phase_status="completed")
+        with pytest.raises(ValueError, match="only valid at phase 4"):
+            feedback_loop(s, max_iterations=3)
+
+    def test_not_completed_raises(self):
+        s = make_state(current_phase=4, phase_status="in_progress")
+        with pytest.raises(ValueError, match="expected completed"):
+            feedback_loop(s, max_iterations=3)
+
+    def test_iterations_exhausted_raises(self):
+        s = make_state(current_phase=4, phase_status="completed",
+                       feedback_iterations=3)
+        with pytest.raises(ValueError, match="Feedback iterations exhausted"):
+            feedback_loop(s, max_iterations=3)
+
+    def test_increments_feedback_iterations(self):
+        s = make_state(current_phase=4, phase_status="completed",
+                       feedback_iterations=1)
+        result = feedback_loop(s, max_iterations=3)
+        assert result["feedback_iterations"] == 2
+
+
+# --- is_review_complete ---
+
+class TestIsReviewComplete:
+    def test_true_when_phase5_completed(self):
+        s = make_state(current_phase=5, phase_status="completed",
+                       phase_completed=[True]*6)
+        assert is_review_complete(s) is True
+
+    def test_false_when_not_phase5(self):
+        s = make_state(current_phase=4, phase_status="completed")
+        assert is_review_complete(s) is False
+
+    def test_false_when_phase5_not_completed(self):
+        s = make_state(current_phase=5, phase_status="in_progress")
+        assert is_review_complete(s) is False
+
+
+# --- Full lifecycle integration ---
+
+class TestFullLifecycle:
+    def test_phase_0_through_5(self):
+        """Walk through phases 0-5 to verify forward progress."""
+        s = make_state()
+        for phase in range(6):
+            s = start_phase(s, phase)
+            s = complete_phase(s, phase)
+            if phase < 5:
+                s = transition_to_next(s)
+        assert is_review_complete(s) is True
+
+    def test_fail_and_retry(self):
+        """Fail a phase, retry it, then complete."""
+        s = make_state()
+        s = start_phase(s, 0)
+        s = fail_phase(s, 0)
+        s = retry_phase(s)
+        # now in_progress again
+        s = complete_phase(s, 0)
+        assert s["phase_status"] == PhaseStatus.COMPLETED
+        assert s["retry_count"] == 1


### PR DESCRIPTION
## Summary
- Add `tests/test_state.py` (34 tests): full coverage of the phase state machine including `make_state`, all transition functions, precondition violations (`ValueError`), and a complete lifecycle integration test (phases 0-5)
- Add `tests/test_saturation.py` (18 tests): `discovery_saturation`, `conceptual_saturation`, `should_terminate_discovery`, and `should_feedback_loop` with exact `Fraction` arithmetic, empty inputs, and threshold boundary semantics
- Add `tests/test_metrics.py` (24 tests): all counting functions (`count_excluded`, `count_flagged`, `count_included`, `count_candidates`, `max_snowball_depth`, `count_concepts`, `count_extractions`), `recompute_all` integration, deduplication in `count_extractions`, and accounting identity verification
- Add `tests/test_e2e_extraction.py` (4 tests): `validate_synthesis_claims` end-to-end extraction completeness propagation — verifies `[limited data]` marker enforcement for low-completeness citations

## Test plan
- [x] All 192 tests pass (`pytest tests/ -v`) — 90 new + 102 existing
- [x] No test isolation issues (pure functions, no file I/O)

Closes #2, closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)