### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stepwise",
       "source": "./",
       "description": "Autonomous systematic literature review with verified inference quarantine, PRISMA compliance, and multi-database search",
-      "version": "0.2.0"
+      "version": "0.2.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stepwise",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Autonomous systematic literature review with verified inference quarantine, PRISMA compliance, and multi-database search",
   "author": {
     "name": "Lionel Di Giacomo"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Six sequential phases, each with defined postconditions that must pass before th
 | Phase | Name | Mode | Work |
 |-------|------|------|------|
 | 0 | Protocol Definition | Interactive | User and orchestrator collaboratively define research question, search strategy, inclusion/exclusion criteria, extraction schema, and phase bounds |
-| 1 | Search | Autonomous | Execute Boolean queries against Semantic Scholar and arXiv; collect candidate corpus |
+| 1 | Search | Autonomous | Execute queries against Semantic Scholar, arXiv, and PubMed; collect candidate corpus |
 | 2 | Screening | Autonomous | Evaluate each candidate against inclusion/exclusion criteria; produce included corpus |
 | 3 | Snowballing | Autonomous | Forward and backward citation traversal from included papers; screen new candidates; terminate on discovery saturation (`θ_d`) or max depth |
 | 4 | Extraction | Autonomous | Extract protocol-defined fields from each included paper; identify concepts; check conceptual saturation (`θ_c`) — loop back to Phase 3 if concept space is still expanding |
@@ -64,7 +64,7 @@ The state machine (phase transitions, retry bounds, status validity) and saturat
 | `spec/state.dfy` | Forward progress, no phase skipping, feedback bound, retry bound (≤1), terminal correctness, monotonic completion |
 | `spec/saturation.dfy` | Range [0,1], zero-denominator safety, termination threshold, feedback bound |
 
-Python implementations in `lib/` mirror the Dafny specs and are tested (85 tests, pytest).
+Python implementations in `lib/` mirror the Dafny specs and are tested (222 tests, pytest).
 
 ## Installation
 


### PR DESCRIPTION
## Summary
Version bump and README update reflecting the 5 merged PRs (#19-#23).

## Changes
- plugin.json: 0.2.1 → 0.2.2
- marketplace.json: 0.2.0 → 0.2.2
- README.md: test count 85 → 222, Phase 1 description updated for PubMed

## Fixes included in 0.2.2
- Postcondition parser scoped to Search Terms section (#14)
- Count-based query matching (#15)
- Search-log event entry crash (#18)
- Phase 3 depth-cap and ID resolution (#16, #17)
- Multi-citation splitting (#4)
- Snowball metadata enrichment runbook (#18, #1)
- Test coverage for state, saturation, metrics (#2, #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)